### PR TITLE
update maven central url

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -3,7 +3,7 @@
 jdk:
   - oraclejdk8
 before_install:
-   - wget http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.3.9/sbt-launch-1.3.9.jar
+   - wget https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/1.3.9/sbt-launch-1.3.9.jar
 install:
    - java -jar sbt-launch-1.3.9.jar +publishM2
    - SCALAJS_VERSION=0.6.32 java -jar sbt-launch-1.3.9.jar ++2.13.0 publishM2


### PR DESCRIPTION
See: https://central.sonatype.org/articles/2019/Jul/15/central-http-deprecation-update/  

Ninja Edit:  
Successful build here: https://jitpack.io/com/github/busti/bench/2960c8c/build.log